### PR TITLE
Minor change to enable wifi_csi to work on ESP32 boards.

### DIFF
--- a/components/wifi_csi/wifi_csi.h
+++ b/components/wifi_csi/wifi_csi.h
@@ -13,7 +13,14 @@
 #include "esphome/core/log.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/wifi/wifi_component.h"
+#ifdef USE_ESP32
+#include <WiFi.h>
+#endif
+
+#ifdef USE_ESP8266
 #include <ESP8266WiFi.h>
+#endif
+
 
 namespace esphome {
 namespace wifi_csi {


### PR DESCRIPTION
Quick header change so its not limited to just ESP8266 boards. 